### PR TITLE
also build for python3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,12 @@ environment:
     - CONFIG: win_c_compilervs2008python2.7
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
+    - CONFIG: win_c_compilervs2015python3.6
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_c_compilervs2015python3.7
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/.ci_support/linux_c_compilergccpython3.6.yaml
+++ b/.ci_support/linux_c_compilergccpython3.6.yaml
@@ -13,7 +13,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'
 zip_keys:
 - - c_compiler
   - channel_sources

--- a/.ci_support/linux_c_compilergccpython3.7.yaml
+++ b/.ci_support/linux_c_compilergccpython3.7.yaml
@@ -13,7 +13,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.7'
 zip_keys:
 - - c_compiler
   - channel_sources

--- a/.ci_support/linux_c_compilertoolchain_cpython3.6.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cpython3.6.yaml
@@ -1,19 +1,19 @@
 build_number_decrement:
-- '0'
+- '1000'
 c_compiler:
-- gcc
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
+- conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'
 zip_keys:
 - - c_compiler
   - channel_sources

--- a/.ci_support/linux_c_compilertoolchain_cpython3.7.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cpython3.7.yaml
@@ -1,19 +1,19 @@
 build_number_decrement:
-- '0'
+- '1000'
 c_compiler:
-- gcc
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
+- conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.7'
 zip_keys:
 - - c_compiler
   - channel_sources

--- a/.ci_support/osx_c_compilerclangpython3.6.yaml
+++ b/.ci_support/osx_c_compilerclangpython3.6.yaml
@@ -1,22 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 build_number_decrement:
 - '0'
 c_compiler:
-- gcc
+- clang
 channel_sources:
 - conda-forge/label/gcc7,defaults
 channel_targets:
 - conda-forge gcc7
-docker_image:
-- condaforge/linux-anvil-comp7
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'
 zip_keys:
 - - c_compiler
   - channel_sources
   - channel_targets
-  - docker_image
   - build_number_decrement

--- a/.ci_support/osx_c_compilerclangpython3.7.yaml
+++ b/.ci_support/osx_c_compilerclangpython3.7.yaml
@@ -1,22 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 build_number_decrement:
 - '0'
 c_compiler:
-- gcc
+- clang
 channel_sources:
 - conda-forge/label/gcc7,defaults
 channel_targets:
 - conda-forge gcc7
-docker_image:
-- condaforge/linux-anvil-comp7
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.7'
 zip_keys:
 - - c_compiler
   - channel_sources
   - channel_targets
-  - docker_image
   - build_number_decrement

--- a/.ci_support/osx_c_compilertoolchain_cpython3.6.yaml
+++ b/.ci_support/osx_c_compilertoolchain_cpython3.6.yaml
@@ -1,22 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 build_number_decrement:
-- '0'
+- '1000'
 c_compiler:
-- gcc
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
-docker_image:
-- condaforge/linux-anvil-comp7
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'
 zip_keys:
 - - c_compiler
   - channel_sources
   - channel_targets
-  - docker_image
   - build_number_decrement

--- a/.ci_support/osx_c_compilertoolchain_cpython3.7.yaml
+++ b/.ci_support/osx_c_compilertoolchain_cpython3.7.yaml
@@ -1,22 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 build_number_decrement:
-- '0'
+- '1000'
 c_compiler:
-- gcc
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
-docker_image:
-- condaforge/linux-anvil-comp7
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.7'
 zip_keys:
 - - c_compiler
   - channel_sources
   - channel_targets
-  - docker_image
   - build_number_decrement

--- a/.ci_support/win_c_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015python3.6.yaml
@@ -1,0 +1,15 @@
+c_compiler:
+- vs2015
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'
+zip_keys:
+- - python
+  - c_compiler

--- a/.ci_support/win_c_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015python3.7.yaml
@@ -1,0 +1,15 @@
+c_compiler:
+- vs2015
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'
+zip_keys:
+- - python
+  - c_compiler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,79 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
+  build_linux_c_compilergccpython3.6:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_c_compilergccpython3.6"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_c_compilergccpython3.7:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_c_compilergccpython3.7"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
   build_linux_c_compilertoolchain_cpython2.7:
     working_directory: ~/test
     machine: true
     environment:
       - CONFIG: "linux_c_compilertoolchain_cpython2.7"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_c_compilertoolchain_cpython3.6:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_c_compilertoolchain_cpython3.6"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_c_compilertoolchain_cpython3.7:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_c_compilertoolchain_cpython3.7"
     steps:
       - checkout
       - run:
@@ -41,4 +109,8 @@ workflows:
   build_and_test:
     jobs:
       - build_linux_c_compilergccpython2.7
+      - build_linux_c_compilergccpython3.6
+      - build_linux_c_compilergccpython3.7
       - build_linux_c_compilertoolchain_cpython2.7
+      - build_linux_c_compilertoolchain_cpython3.6
+      - build_linux_c_compilertoolchain_cpython3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ osx_image: xcode6.4
 env:
   matrix:
     - CONFIG=osx_c_compilerclangpython2.7
+    - CONFIG=osx_c_compilerclangpython3.6
+    - CONFIG=osx_c_compilerclangpython3.7
     - CONFIG=osx_c_compilertoolchain_cpython2.7
+    - CONFIG=osx_c_compilertoolchain_cpython3.6
+    - CONFIG=osx_c_compilertoolchain_cpython3.7
 
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [not py2k]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
subprocess32 can be installed on python3 systems and then simply links to subprocess.
```
On Python 3, it merely redirects the subprocess32 name to subprocess.
```
See: https://pypi.org/project/subprocess32/

Building for python3 as well would avoid having to patch the source code in one of the packages I would like to contribute 
:-)